### PR TITLE
Add double-quote as a character to be percent escaped

### DIFF
--- a/src/main/scala/com/netaporter/uri/encoding/PercentEncoder.scala
+++ b/src/main/scala/com/netaporter/uri/encoding/PercentEncoder.scala
@@ -32,10 +32,12 @@ object PercentEncoder {
   val GEN_DELIMS = Set(':', '/', '?',  '#', '[', ']', '@')
   val SUB_DELIMS  = Set('!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '=')
   val RESERVED = GEN_DELIMS ++ SUB_DELIMS
-  
+
+  val EXCLUDED = Set('"') // RFC 2396 section 2.4.3
+
   /**
    * Probably more than you need to percent encode. Wherever possible try to use a tighter Set of characters
    * to encode depending on your use case
    */
-  val DEFAULT_CHARS_TO_ENCODE = RESERVED ++ PATH_CHARS_TO_ENCODE ++ QUERY_CHARS_TO_ENCODE
+  val DEFAULT_CHARS_TO_ENCODE = RESERVED ++ PATH_CHARS_TO_ENCODE ++ QUERY_CHARS_TO_ENCODE ++ EXCLUDED
 }

--- a/src/test/scala/com/netaporter/uri/EncodingTests.scala
+++ b/src/test/scala/com/netaporter/uri/EncodingTests.scala
@@ -28,6 +28,11 @@ class EncodingTests extends FlatSpec with Matchers {
     uri.toString should equal ("http://theon.github.com/uri%20with%20space")
   }
 
+  "URI path double quotes" should "be percent encoded when using conservative encoder" in {
+    val uri: Uri = "http://theon.github.com" / "what-she-said" / """"that""""
+    uri.toString(UriConfig.conservative) should equal ("http://theon.github.com/what-she-said/%22that%22")
+  }
+
   "URI path spaces" should "be plus encoded if configured" in {
     implicit val config = UriConfig(encoder = percentEncode + spaceAsPlus)
     val uri: Uri = "http://theon.github.com" / "uri with space"
@@ -43,6 +48,11 @@ class EncodingTests extends FlatSpec with Matchers {
   "Querystring parameters" should "be percent encoded" in {
     val uri = "http://theon.github.com/uris-in-scala.html" ? ("càsh" -> "+£50") & ("©opyright" -> "false")
     uri.toString should equal ("http://theon.github.com/uris-in-scala.html?c%C3%A0sh=%2B%C2%A350&%C2%A9opyright=false")
+  }
+
+  "Querystring double quotes" should "be percent encoded when using conservative encoder" in {
+    val uri: Uri = "http://theon.github.com" ? ("what-she-said" -> """"that"""")
+    uri.toString(UriConfig.conservative) should equal ("http://theon.github.com?what-she-said=%22that%22")
   }
 
   "Reserved characters" should "be percent encoded when using conservative encoder" in {


### PR DESCRIPTION
[RFC 2396](https://www.ietf.org/rfc/rfc2396.txt) defines a set of excluded characters that should be escaped; most of these are covered already by RFC 3986, but not the double quote character.

The reason for its inclusion is

>double-quote (") characters are excluded because they are often used as the delimiters around URI in text documents and protocol fields.

For example:

`<a href="http://beachape.com/"hello"">` would be problematic.