### PR TITLE
Accept empty passwords in parser

### DIFF
--- a/src/main/scala/com/netaporter/uri/parsing/DefaultUriParser.scala
+++ b/src/main/scala/com/netaporter/uri/parsing/DefaultUriParser.scala
@@ -16,7 +16,7 @@ class DefaultUriParser(val input: ParserInput, conf: UriConfig) extends Parser w
   }
 
   def _userInfo: Rule1[UserInfo] = rule {
-    capture(oneOrMore(!anyOf(":/?@") ~ ANY)) ~ optional(":" ~ capture(oneOrMore(!anyOf("@") ~ ANY))) ~ "@" ~> extractUserInfo
+    capture(oneOrMore(!anyOf(":/?@") ~ ANY)) ~ optional(":" ~ optional(capture(oneOrMore(!anyOf("@") ~ ANY)))) ~ "@" ~> extractUserInfo
   }
 
   //TODO Try harder to make this a Rule1[Int] using ~> extractInt

--- a/src/main/scala/com/netaporter/uri/parsing/UriParser.scala
+++ b/src/main/scala/com/netaporter/uri/parsing/UriParser.scala
@@ -21,8 +21,8 @@ trait UriParser {
   val extractInt = (num: String) =>
     num.toInt
 
-  val extractUserInfo = (user: String, pass: Option[String]) =>
-    UserInfo(pathDecoder.decode(user), pass.map(pathDecoder.decode))
+  val extractUserInfo = (user: String, pass: Option[Option[String]]) =>
+    UserInfo(pathDecoder.decode(user), pass.map(_.fold("")(pathDecoder.decode)))
 
   val extractAuthority = (userInfo: Option[UserInfo], host: String, port: Option[String]) =>
     Authority(userInfo.map(_.user), userInfo.flatMap(_.pass), host, port.map(_.toInt))

--- a/src/test/scala/com/netaporter/uri/ParsingTests.scala
+++ b/src/test/scala/com/netaporter/uri/ParsingTests.scala
@@ -105,6 +105,14 @@ class ParsingTests extends FlatSpec with Matchers {
     uri.host should equal(Some("github.com"))
   }
 
+  "Parsing a with user and empty password" should "result in a Uri with the user and empty password" in {
+    val uri = parse("ftp://theon:@github.com")
+    uri.scheme should equal(Some("ftp"))
+    uri.user should equal(Some("theon"))
+    uri.password should equal(Some(""))
+    uri.host should equal(Some("github.com"))
+  }
+
   "Protocol relative url with authority" should "parse correctly" in {
     val uri = parse("//user:pass@www.mywebsite.com/index.html")
     uri.scheme should equal(None)


### PR DESCRIPTION
Currently, a `java.net.URISyntaxException` is raised when attempting to parse an URI with an empty password, such as `ftp://theon:@github.com`. However, it is possible to generate such an URI with scala-uri by calling `.withPassword("")`. This makes scala-uri unable to parse some of the URIs generated by itself.

This illustrates the problem :
```
scala> import com.netaporter.uri.Uri._
import com.netaporter.uri.Uri._

scala> parse("ftp://theon:password@github.com")
res0: com.netaporter.uri.Uri = ftp://theon:password@github.com

scala> parse("ftp://theon:password@github.com").withPassword("")
res1: com.netaporter.uri.Uri = ftp://theon:@github.com

scala> parse(res1.toString)
java.net.URISyntaxException: Invalid URI could not be parsed. Vector(RuleTrace(List(NonTerminal(Named(_uri),-12), NonTerminal(RuleCall,-12), NonTerminal(Sequence,-12), NonTerminal(FirstOf,-12), NonTerminal(Named(_abs_uri),-12), NonTerminal(RuleCall,-12), NonTerminal(Sequence,-12), NonTerminal(Optional,-6), NonTerminal(Named(_authority),-6), NonTerminal(RuleCall,-6), NonTerminal(Sequence,-6), NonTerminal(FirstOf,-6), NonTerminal(Sequence,-6), NonTerminal(Optional,-6), NonTerminal(Named(_userInfo),-6), NonTerminal(RuleCall,-6), NonTerminal(Sequence,-6), NonTerminal(Optional,-1), NonTerminal(Sequence,-1), NonTerminal(Capture,0), NonTerminal(OneOrMore,0), NonTerminal(Sequence,0)),NotPredicate(Terminal(AnyOf(@)),1)), RuleTrace(List(NonTerminal(Named(_uri),-12), NonTerminal(RuleCall,-12), NonTerminal(Sequence,-12), NonTerminal(FirstOf,-12), NonTerminal(Named(_abs_uri),-12), NonTerminal(RuleCall,-12), NonTerminal(Sequence,-12), NonTerminal(Optional,-6), NonTerminal(Named(_authority),-6), NonTerminal(RuleCall,-6), NonTerminal(Sequence,-6), NonTerminal(FirstOf,-6), NonTerminal(Sequence,-6), NonTerminal(Optional,-1), NonTerminal(Named(_port),-1), NonTerminal(RuleCall,-1), NonTerminal(Sequence,-1), NonTerminal(Capture,0), NonTerminal(OneOrMore,0), NonTerminal(Named(Digit),0)),CharPredicateMatch(CharPredicate.MaskBased(0123456789)))) at index 12: ftp://theon:@github.com
  at com.netaporter.uri.parsing.UriParser$.parse(UriParser.scala:67)
  at com.netaporter.uri.Uri$.parse(Uri.scala:288)
  ... 43 elided
```

To make the behavior more coherent, this PR updates the parser to accept empty passwords :
```
scala> import com.netaporter.uri.Uri._
import com.netaporter.uri.Uri._

scala> parse("ftp://theon:password@github.com")
res0: com.netaporter.uri.Uri = ftp://theon:password@github.com

scala> parse("ftp://theon:password@github.com").withPassword("")
res1: com.netaporter.uri.Uri = ftp://theon:@github.com

scala> parse(res1.toString)
res2: com.netaporter.uri.Uri = ftp://theon:@github.com
```