### PR TITLE
Fix issue #107 where /path and path were being considered the same

### DIFF
--- a/src/main/scala/com/netaporter/uri/PathPart.scala
+++ b/src/main/scala/com/netaporter/uri/PathPart.scala
@@ -70,4 +70,6 @@ case class MatrixParams(part: String, params: ParamSeq) extends PathPart with Pa
 object PathPart {
   def apply(path: String, matrixParams: ParamSeq = Seq.empty) =
     if(matrixParams.isEmpty) new StringPathPart(path) else MatrixParams(path, matrixParams)
+
+  val Empty = new StringPathPart("")
 }

--- a/src/main/scala/com/netaporter/uri/dsl/UriDsl.scala
+++ b/src/main/scala/com/netaporter/uri/dsl/UriDsl.scala
@@ -1,6 +1,6 @@
 package com.netaporter.uri.dsl
 
-import com.netaporter.uri.{Uri, StringPathPart}
+import com.netaporter.uri.{PathPart, Uri, StringPathPart}
 
 /**
  * Value class to add DSL functionality to Uris
@@ -47,7 +47,11 @@ class UriDsl(val uri: Uri) extends AnyVal {
    * @param pp The path part
    * @return A new Uri with this path part appended
    */
-  def /(pp: String) = uri.copy(pathParts = uri.pathParts :+ StringPathPart(pp))
+  def /(pp: String) = {
+    // If there is no path already, add an empty path segment to create the leading slash
+    val before = if(uri.rawPathParts.isEmpty) Seq(PathPart.Empty) else uri.rawPathParts
+    uri.copy(rawPathParts = before :+ StringPathPart(pp))
+  }
 
   /**
    * Operator precedence in Scala will mean that our DSL will not always be executed left to right.
@@ -62,7 +66,7 @@ class UriDsl(val uri: Uri) extends AnyVal {
    *
    * (see Scala Reference - 6.12.3 Infix Operations: http://www.scala-lang.org/docu/files/ScalaReference.pdf)
    *
-   * To handle cases where the right hard part of the DSL is executed first, we turn that into a Uri, and merge
+   * To handle cases where the right hand part of the DSL is executed first, we turn that into a Uri, and merge
    * it with the left had side. It is assumed the right hand Uri is generated from this DSL only to add path
    * parts, query parameters or to overwrite the fragment
    *
@@ -71,7 +75,7 @@ class UriDsl(val uri: Uri) extends AnyVal {
    */
   private def merge(other: Uri) =
     uri.copy(
-      pathParts = uri.pathParts ++ other.pathParts,
+      rawPathParts = uri.rawPathParts ++ other.rawPathParts,
       query = uri.query.addParams(other.query),
       fragment = other.fragment.orElse(uri.fragment)
     )

--- a/src/main/scala/com/netaporter/uri/parsing/DefaultUriParser.scala
+++ b/src/main/scala/com/netaporter/uri/parsing/DefaultUriParser.scala
@@ -33,17 +33,10 @@ class DefaultUriParser(val input: ParserInput, conf: UriConfig) extends Parser w
   }
 
   /**
-   * A sequence of path parts that MUST start with a slash
+   * A sequence of path parts
    */
-  def _abs_path: Rule1[Vector[PathPart]] = rule {
-    zeroOrMore("/" ~ _pathSegment) ~> extractPathParts
-  }
-
-  /**
-   * A sequence of path parts optionally starting with a slash
-   */
-  def _rel_path: Rule1[Vector[PathPart]] = rule {
-    optional("/") ~ zeroOrMore(_pathSegment).separatedBy("/") ~> extractPathParts
+  def _path: Rule1[Vector[PathPart]] = rule {
+    zeroOrMore(_pathSegment).separatedBy("/") ~> extractPathParts
   }
 
   def _queryParam: Rule1[Param] = rule {
@@ -63,15 +56,15 @@ class DefaultUriParser(val input: ParserInput, conf: UriConfig) extends Parser w
   }
 
   def _abs_uri: Rule1[Uri] = rule {
-    _scheme ~ "://" ~ optional(_authority) ~ _abs_path ~ optional(_queryString) ~ optional(_fragment) ~> extractAbsUri
+    _scheme ~ "://" ~ optional(_authority) ~ _path ~ optional(_queryString) ~ optional(_fragment) ~> extractAbsUri
   }
 
   def _protocol_rel_uri: Rule1[Uri] = rule {
-    "//" ~ optional(_authority) ~ _abs_path ~ optional(_queryString) ~ optional(_fragment) ~> extractProtocolRelUri
+    "//" ~ optional(_authority) ~ _path ~ optional(_queryString) ~ optional(_fragment) ~> extractProtocolRelUri
   }
 
   def _rel_uri: Rule1[Uri] = rule {
-    _rel_path ~ optional(_queryString) ~ optional(_fragment) ~> extractRelUri
+    _path ~ optional(_queryString) ~ optional(_fragment) ~> extractRelUri
   }
 
   def _uri: Rule1[Uri] = rule {
@@ -113,7 +106,7 @@ class DefaultUriParser(val input: ParserInput, conf: UriConfig) extends Parser w
       password = authority.flatMap(_.password),
       host = authority.map(_.host),
       port = authority.flatMap(_.port),
-      pathParts = pathParts,
+      rawPathParts = pathParts,
       query = query.getOrElse(EmptyQueryString),
       fragment = fragment
     )

--- a/src/test/scala/com/netaporter/uri/GithubIssueTests.scala
+++ b/src/test/scala/com/netaporter/uri/GithubIssueTests.scala
@@ -46,7 +46,7 @@ class GithubIssueTests extends FlatSpec with Matchers with OptionValues {
 
     uri.scheme should equal (None)
     uri.host should equal (None)
-    uri.path should equal ("/abc")
+    uri.path should equal ("abc")
   }
 
   "Github Issue #15" should "now be fixed. Empty Query String values are parsed" in {
@@ -172,5 +172,10 @@ class GithubIssueTests extends FlatSpec with Matchers with OptionValues {
 
     val withPathAndQuery = p / "some/path/segments" ? ("returnUrl" -> "http://localhost:1234/some/path/segments")
     withPathAndQuery.toString should equal("http://localhost:1234/some/path/segments?returnUrl=http://localhost:1234/some/path/segments")
+  }
+
+  "Github Issue #107" should "now be fixed. path and /path are now treated differently" in {
+    Uri.parse("path").toString should equal("path")
+    Uri.parse("/path").toString should equal("/path")
   }
 }


### PR DESCRIPTION
Possible fix for #107.

This change uses a leading empty path part for situations where we want a leading slash in the path. I'm not overly convinced this is the best way to fix this. Open to other suggestions.