### PR TITLE
update spray-json to avoid vulnerability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8", "-featur
 
 libraryDependencies += "org.parboiled" %% "parboiled" % "2.1.3"
 
-libraryDependencies += "io.spray" %%  "spray-json" % "1.3.2"
+libraryDependencies += "io.spray" %%  "spray-json" % "1.3.5"
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.0" % "test"
 


### PR DESCRIPTION
1.3.2 is vulnerable to two DoS attacks, 1.3.5 has been released for many months which is not vulnerable so should be reliable.
See these for more details:
https://app.snyk.io/vuln/SNYK-JAVA-IOSPRAY-474271
https://app.snyk.io/vuln/SNYK-JAVA-IOSPRAY-474269